### PR TITLE
Update install instructions for asset building

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,8 @@ add your database details to .env, then:
 composer install
 php artisan migrate
 php artisan db:seed
+npm install
+gulp
 ```
 
 ## Serve


### PR DESCRIPTION
Compiled assets are not included and must be build. Added `npm install` and `gulp` steps to the installation instructions.
