### PR TITLE
Fixed Auth bug introduced in 5.3 upgrade

### DIFF
--- a/resources/views/layouts/nav.blade.php
+++ b/resources/views/layouts/nav.blade.php
@@ -46,7 +46,17 @@
                         </a>
 
                         <ul class="dropdown-menu" role="menu">
-                            <li><a href="{{ url('/logout') }}"><i class="fa fa-btn fa-sign-out"></i>Logout</a></li>
+                            <li>
+                                <a href="{{ url('/logout') }}"
+                                   onclick="event.preventDefault();
+                                                 document.getElementById('logout-form').submit();">
+                                    Logout
+                                </a>
+
+                                <form id="logout-form" action="{{ url('/logout') }}" method="POST" style="display: none;">
+                                    {{ csrf_field() }}
+                                </form>
+                            </li>
                         </ul>
                     </li>
                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 Auth::routes();
 
+Route::get('/logout', 'Auth\LoginController@logout');
+
 Route::get('/deploy', [ 'middleware' => 'throttle:2', function () {
 
     $script = base_path('deploy.sh');

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class AuthTest extends TestCase
+{
+    use Illuminate\Foundation\Testing\DatabaseTransactions;
+    /**
+     * @test
+     */
+    public function loginTest()
+    {
+        $user = factory(App\User::class)->create([
+            'password' => bcrypt('secret')
+        ]);
+
+        $this->visit("/")
+            ->click("Login")
+            ->type($user->email, 'email')
+            ->type('secret', 'password')
+            ->press('Login')
+            ->seePageIs('/home');
+    }
+
+    /**
+     * @test
+     */
+    public function logoutTest()
+    {
+        $user = factory(App\User::class)->create();
+        $this->actingAs($user)
+            ->visit("/home")
+            ->click("Logout")
+            ->seePageIs("/");
+    }
+
+    /**
+     * @test
+     */
+    public function registerTest()
+    {
+        $this->visit("/register")
+            ->type('John Doe', 'name')
+            ->type('john@doe.com', 'email')
+            ->type('secret', 'password')
+            ->type('secret', 'password_confirmation')
+            ->press('Register')
+            ->seeInDatabase('users', ['name' => 'John Doe', 'email' => 'john@doe.com']);
+    }
+}


### PR DESCRIPTION
In laravel 5.3 the logout route is a post route. Copied the html for logout from the 5.3 default scaffold, added the get route (mainly for tests) and added tests for login, logout and register
